### PR TITLE
play 2.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target/*
 project/target/*
 project/**/target/*
+.idea
+.idea_modules

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 play-stylus
 ===========
 
-[stylus] [1] asset handling for [Play 2.0] [2], implemented as an [sbt] [3]
+[stylus] [1] asset handling for [Play 2.2] [2], implemented as an [sbt] [3]
 plugin (very similar to Play's handling of CoffeeScript and LESS).
 
 Prerequisites
@@ -22,7 +22,7 @@ In your Play application folder, add
 
     resolvers += "Patience Releases" at "http://repo.patience.io/"
 
-    addSbtPlugin("patience" % "play-stylus" % "0.1.3")
+    addSbtPlugin("patience" % "play-stylus" % "0.2.0")
 
 to `project/plugins.sbt`.
 

--- a/build.sbt
+++ b/build.sbt
@@ -21,10 +21,10 @@ resolvers += new MavenRepository("typesafe-releases", "http://repo.typesafe.com/
 publishTo := Some(Resolver.sftp("Patience", "repo.patience.io", "repo"))
 
 /// Dependencies
+addSbtPlugin("com.typesafe.play" %% "sbt-plugin" % "2.2.0")
 
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play" % "2.2.0",
-  "com.typesafe.play" %% "sbt-plugin" % "2.2.0" from "http://repo.typesafe.com/typesafe/ivy-releases/com.typesafe.play/sbt-plugin/scala_2.10/sbt_0.13/2.2.0/jars/sbt-plugin.jar",
   "org.scalatest" %% "scalatest" % "1.9.1" % "test",
   // ... class file needed by PlayAssetsCompiler is missing. reference value javascript of package com.google refers to nonexisting symbol...
   "com.google.javascript" % "closure-compiler" % "r1043"

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,10 @@ sbtPlugin := true
 
 version := "0.1.3"
 
+// 2.9.2 has internal bug (AssertError in traits), that prevents project from building.
+// 2.10.0 has no sbt-plugin. So, let's use 2.9.3
+scalaVersion := "2.9.3"
+
 organization := "patience"
 
 description := "sbt plugin for handling stylus assets in Play"
@@ -19,7 +23,9 @@ publishTo := Some(Resolver.sftp("Patience", "repo.patience.io", "repo"))
 /// Dependencies
 
 libraryDependencies ++= Seq(
-  "play" %% "play" % "2.0",
-  "play" % "sbt-plugin" % "2.0" from "http://repo.typesafe.com/typesafe/releases/play/sbt-plugin/scala_2.9.1/sbt_0.11.2/2.0/jars/sbt-plugin.jar",
-  "org.scalatest" %% "scalatest" % "1.7.1" % "test"
+  "play" %% "play" % "2.1.1",
+  "play" % "sbt-plugin" % "2.1.1" from "http://repo.typesafe.com/typesafe/releases/play/sbt-plugin/scala_2.9.3/sbt_0.12/2.1.1/jars/sbt-plugin.jar",
+  "org.scalatest" %% "scalatest" % "1.9.1" % "test",
+  // ... class file needed by PlayAssetsCompiler is missing. reference value javascript of package com.google refers to nonexisting symbol...
+  "com.google.javascript" % "closure-compiler" % "r1043"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,8 @@ sbtPlugin := true
 version := "0.2.0"
 
 // Incompatible with 2.9.2.
-// 2.9.3, 2.10.x, etc are possible scalaVersions.
-scalaVersion := "2.10.0"
+// 2.9.3 (play 2.1.x), 2.10.2 (play 2.2.x) are known-to-compile scalaVersions.
+scalaVersion := "2.10.2"
 
 organization := "patience"
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,11 +4,11 @@ name := "play-stylus"
 
 sbtPlugin := true
 
-version := "0.1.3"
+version := "0.2.0"
 
-// 2.9.2 has internal bug (AssertError in traits), that prevents project from building.
-// 2.10.0 has no sbt-plugin. So, let's use 2.9.3
-scalaVersion := "2.9.3"
+// Incompatible with 2.9.2.
+// 2.9.3, 2.10.x, etc are possible scalaVersions.
+scalaVersion := "2.10.0"
 
 organization := "patience"
 
@@ -23,8 +23,8 @@ publishTo := Some(Resolver.sftp("Patience", "repo.patience.io", "repo"))
 /// Dependencies
 
 libraryDependencies ++= Seq(
-  "play" %% "play" % "2.1.1",
-  "play" % "sbt-plugin" % "2.1.1" from "http://repo.typesafe.com/typesafe/releases/play/sbt-plugin/scala_2.9.3/sbt_0.12/2.1.1/jars/sbt-plugin.jar",
+  "com.typesafe.play" %% "play" % "2.2.0",
+  "com.typesafe.play" %% "sbt-plugin" % "2.2.0" from "http://repo.typesafe.com/typesafe/ivy-releases/com.typesafe.play/sbt-plugin/scala_2.10/sbt_0.13/2.2.0/jars/sbt-plugin.jar",
   "org.scalatest" %% "scalatest" % "1.9.1" % "test",
   // ... class file needed by PlayAssetsCompiler is missing. reference value javascript of package com.google refers to nonexisting symbol...
   "com.google.javascript" % "closure-compiler" % "r1043"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.0

--- a/src/main/scala/patience/assets/StylusCompiler.scala
+++ b/src/main/scala/patience/assets/StylusCompiler.scala
@@ -19,7 +19,7 @@ object StylusCompiler {
       (cssOutput, Some(compressedCssOutput), Seq(stylFile))
     } catch {
       case e: StylusCompilationException => {
-        throw AssetCompilationException(Some(stylFile), "Stylus compiler: " + e.message, e.line, e.column)
+        throw AssetCompilationException(Some(stylFile), "Stylus compiler: " + e.message, Some(e.line), Some(e.column))
       }
     }
   }

--- a/src/main/scala/patience/assets/StylusCompiler.scala
+++ b/src/main/scala/patience/assets/StylusCompiler.scala
@@ -1,6 +1,6 @@
 package patience.assets
 
-import sbt.PlayExceptions.AssetCompilationException
+import play.PlayExceptions.AssetCompilationException
 import java.io.File
 import scala.sys.process._
 
@@ -36,7 +36,7 @@ object StylusCompiler {
     if (process.exitValue == 0)
       out.toString
     else
-      throw new StylusCompilationException(err.toString)
+      throw new StylusCompilationException(err.toString())
   }
 
   private val MarkedLine = """\s*>\s*(\d+)\|.*?""".r

--- a/src/main/scala/patience/assets/StylusCompiler.scala
+++ b/src/main/scala/patience/assets/StylusCompiler.scala
@@ -49,7 +49,7 @@ object StylusCompiler {
     private def parseError(error: String): (Int, Int, String) = {
       var seen = 0
       var line = 0
-      var column = 0
+      val column = 0
       var message = "Unknown error, try running stylus directly"
       for (errline: String <- augmentString(error).lines) {
         errline match {

--- a/src/main/scala/patience/assets/StylusPlugin.scala
+++ b/src/main/scala/patience/assets/StylusPlugin.scala
@@ -2,22 +2,22 @@ package patience.assets
 
 import sbt._
 import sbt.Keys._
-import PlayProject._
+import play.{Project => PlayProject}
 
 object StylusPlugin extends Plugin {
 
   val stylusEntryPoints = SettingKey[PathFinder]("play-stylus-entry-points")
   val stylusOptions = SettingKey[Seq[String]]("play-stylus-options")
   val StylusWatcher = PlayProject.AssetsCompiler("stylus",
-    (_ ** "*.styl"),
+    _ ** "*.styl",
     stylusEntryPoints in Compile,
     { (name, min) => name.replace(".styl", if (min) ".min.css" else ".css") },
-    { StylusCompiler.compile _ },
+    { StylusCompiler.compile },
     stylusOptions in Compile
   )
 
   override val settings = Seq(
-    stylusEntryPoints <<= (sourceDirectory in Compile).apply(base => ((base / "assets" ** "*.styl") --- base / "assets" ** "_*")),
+    stylusEntryPoints <<= (sourceDirectory in Compile).apply(base => (base / "assets" ** "*.styl") --- base / "assets" ** "_*"),
     stylusOptions := Seq.empty[String],
     resourceGenerators in Compile <+= StylusWatcher
   )


### PR DESCRIPTION
Yes, it works, but pull request contains one issue, that i'm unable to resolve.

It looks like scalac 2.9.2 contains some crazy bug, that raises exception on correct sbt.PlayExceptions-2.1.1. So, 2.9.3 is used. And this is the issue.

If 2.9.3-build will be published somewhere, fake scala version, hardcoded dependency url or other workaround is needed because sbt-plugin is looking for 2.9.2. So, changes in README will be also needed.

// And it looks like play-framework 2.1.1 cannot be built using 2.9.2 too.
