### PR TITLE
Fixed overriden settings which clashed with non-play submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,15 @@ In your Play application folder, add
 
     resolvers += "Patience Releases" at "http://repo.patience.io/"
 
-    addSbtPlugin("patience" % "play-stylus" % "0.2.0")
+    addSbtPlugin("patience" % "play-stylus" % "1.0.0-SNAPSHOT")
 
-to `project/plugins.sbt`.
+to `project/plugins.sbt`, and
 
-The plugin automatically registers for compilation of `app/assets/**/*.styl`, that is all stylus files in your `app/assets` directory.
+    patience.assets.StylusPlugin.stylusSettings
+
+to `build.sbt`.
+
+The plugin registers for compilation of `app/assets/**/*.styl`, that is all stylus files in your `app/assets` directory.
 
 sbt settings
 ------------

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "play-stylus"
 
 sbtPlugin := true
 
-version := "0.2.0"
+version := "1.0.0-SNAPSHOT"
 
 // Incompatible with 2.9.2.
 // 2.9.3 (play 2.1.x), 2.10.2 (play 2.2.x) are known-to-compile scalaVersions.

--- a/src/main/scala/patience/assets/StylusPlugin.scala
+++ b/src/main/scala/patience/assets/StylusPlugin.scala
@@ -16,7 +16,7 @@ object StylusPlugin extends Plugin {
     stylusOptions in Compile
   )
 
-  override val settings = Seq(
+  val stylusSettings = Seq(
     stylusEntryPoints <<= (sourceDirectory in Compile).apply(base => (base / "assets" ** "*.styl") --- base / "assets" ** "_*"),
     stylusOptions := Seq.empty[String],
     resourceGenerators in Compile <+= StylusWatcher


### PR DESCRIPTION
With previous way of declaring settings

```
override val settings = Seq( // ...
```

projects using `play-stylus` and having non-play submodules will fail to run. 

Similar issue with fix: https://github.com/mumoshu/play2-typescript/issues/16
